### PR TITLE
Fix test imports

### DIFF
--- a/src/tests/context.test.tsx
+++ b/src/tests/context.test.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
-import { act } from 'react';
+import { act } from 'react-dom/test-utils';
 import { AppProvider, useAppContext } from '@/context/app-context';
 import { describe, it } from '@/lib/test-runner';
 import { initialCategories, OTHER_CATEGORY_ID } from '@/lib/data';


### PR DESCRIPTION
## Summary
- fix incorrect `act` import in context tests

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'caseless' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68829e1a05b88324a9875266c4a6ebfd