### PR TITLE
Fix test runner import

### DIFF
--- a/src/tests/context.test.tsx
+++ b/src/tests/context.test.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
-import { act } from 'react';
+import { act } from 'react-dom/test-utils';
 import { AppProvider, useAppContext } from '@/context/app-context';
 import { describe, it } from '@/lib/test-runner';
 import { initialCategories, OTHER_CATEGORY_ID } from '@/lib/data';


### PR DESCRIPTION
## Summary
- fix tests by importing `act` from `react-dom/test-utils`

## Testing
- `npm run lint` *(fails: packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882a0235fa88324a5e07ca06ac0ac56