### PR TITLE
Fix React test utils crash

### DIFF
--- a/src/tests/context.test.tsx
+++ b/src/tests/context.test.tsx
@@ -2,11 +2,18 @@
 "use client"
 
 import React from 'react';
-import { createRoot, Root } from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
 import { AppProvider, useAppContext } from '@/context/app-context';
 import { describe, it } from '@/lib/test-runner';
 import { initialCategories, OTHER_CATEGORY_ID } from '@/lib/data';
+
+// react-dom/test-utils is not reliable in this browser-based test environment
+// so we provide a very small replacement that simply awaits the callback and
+// lets React process state updates on the next tick.
+const act = async (fn: () => void | Promise<void>) => {
+  await fn();
+  await new Promise(resolve => setTimeout(resolve, 0));
+};
 
 declare const expect: (actual: any) => any;
 


### PR DESCRIPTION
## Summary
- avoid using `react-dom/test-utils` in tests

The browser-based test runner would crash because `react-dom/test-utils` expects
certain internal fields that aren't available in our Next.js environment. A
lightweight `act` helper keeps the asynchronous flow without relying on these
internals.

## Testing
- `npm run typecheck` *(fails: Cannot find module errors because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882a169d0b88324b33fcbc5415abbaf